### PR TITLE
Sugar 8.1 support

### DIFF
--- a/images/elasticsearch/62/Dockerfile
+++ b/images/elasticsearch/62/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch:6.2
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.2.0
 MAINTAINER enrico.simonetti@gmail.com
 
 COPY config/elasticsearch/elasticsearch.yml /usr/share/elasticsearch/config/elasticsearch.yml

--- a/images/elasticsearch/62/Dockerfile
+++ b/images/elasticsearch/62/Dockerfile
@@ -1,0 +1,4 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:6.2
+MAINTAINER enrico.simonetti@gmail.com
+
+COPY config/elasticsearch/elasticsearch.yml /usr/share/elasticsearch/config/elasticsearch.yml

--- a/images/elasticsearch/62/config/elasticsearch/elasticsearch.yml
+++ b/images/elasticsearch/62/config/elasticsearch/elasticsearch.yml
@@ -1,0 +1,10 @@
+cluster.name: sugarcrm62
+node.name: sugar1
+action.destructive_requires_name: true
+cluster.indices.close.enable: false
+script.inline: false  
+script.stored: false  
+script.file: false 
+script.update: false
+bootstrap.memory_lock: true
+network.host: _site_

--- a/stacks/sugar81/README.md
+++ b/stacks/sugar81/README.md
@@ -5,5 +5,5 @@ This repository will help you deploy a Docker based development full stack for S
 * php71.yml - Main reference stack - Single web server
     * PHP - 7.1
     * MySQL - 5.7
-    * Elasticsearch - 6.2 (note that the hostname is sugar-elasticsearch now)
+    * Elasticsearch - 6.2
     * Redis - latest

--- a/stacks/sugar81/README.md
+++ b/stacks/sugar81/README.md
@@ -1,0 +1,9 @@
+# Sugar Dockerized Sugar version 8.1
+This repository will help you deploy a Docker based development full stack for Sugar version 8.1
+
+## Stacks available
+* php71.yml - Main reference stack - Single web server
+    * PHP - 7.1
+    * MySQL - 5.7
+    * Elasticsearch - 6.2 (note that the hostname is sugar-elasticsearch now)
+    * Redis - latest

--- a/stacks/sugar81/php71-local-build.yml
+++ b/stacks/sugar81/php71-local-build.yml
@@ -1,0 +1,73 @@
+version: '2'
+
+services:
+    web1:
+        container_name: "sugar-web1"
+        image: sugar_php71_web
+        build: ../../images/php/71/apache
+        ports:
+            - "80:80"
+        extra_hosts:
+            - "docker.local:127.0.0.1"
+        volumes:
+            - ../../data/app:/var/www/html
+        depends_on:
+            - mysql
+            - elasticsearch
+            - redis
+            - permissions
+        links:
+            - mysql
+            - elasticsearch
+            - redis
+    cron:
+        container_name: "sugar-cron"
+        image: sugar_php71_cron
+        build: ../../images/php/71/cron
+        volumes:
+            - ../../data/app:/var/www/html
+        depends_on:
+            - mysql
+            - elasticsearch
+            - redis
+            - permissions
+        links:
+            - mysql
+            - elasticsearch
+            - redis
+    mysql:
+        container_name: "sugar-mysql"
+        image: sugar_mysql
+        build: ../../images/mysql/57
+        ports:
+            - "3306:3306"
+        volumes:
+            - ../../data/mysql/57:/var/lib/mysql
+        environment:
+            - MYSQL_ROOT_PASSWORD=root
+            - MYSQL_USER=sugar
+            - MYSQL_PASSWORD=sugar
+    elasticsearch:
+        container_name: "sugar-elasticsearch"
+        image: sugar_elastic62
+        build: ../../images/elasticsearch/62
+        volumes:
+            - ../../data/elasticsearch/62:/usr/share/elasticsearch/data
+        environment:
+            - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+        ulimits:
+            memlock:
+                soft: -1
+                hard: -1
+        mem_limit: 1g
+    redis:
+        container_name: "sugar-redis"
+        image: redis:latest
+        volumes:
+            - ../../data/redis:/data
+    permissions:
+        container_name: "sugar-permissions"
+        image: sugar_permissions
+        build: ../../images/permissions
+        volumes:
+            - ../../data/app:/var/www/html

--- a/stacks/sugar81/php71.yml
+++ b/stacks/sugar81/php71.yml
@@ -1,0 +1,68 @@
+version: '2'
+
+services:
+    web1:
+        container_name: "sugar-web1"
+        image: esimonetti/sugardockerized:php7.1-apache-1.01
+        ports:
+            - "80:80"
+        extra_hosts:
+            - "docker.local:127.0.0.1"
+        volumes:
+            - ../../data/app:/var/www/html
+        depends_on:
+            - mysql
+            - elasticsearch
+            - redis
+            - permissions
+        links:
+            - mysql
+            - elasticsearch
+            - redis
+    cron:
+        container_name: "sugar-cron"
+        image: esimonetti/sugardockerized:php7.1-cron-1.01
+        volumes:
+            - ../../data/app:/var/www/html
+        depends_on:
+            - mysql
+            - elasticsearch
+            - redis
+            - permissions
+        links:
+            - mysql
+            - elasticsearch
+            - redis
+    mysql:
+        container_name: "sugar-mysql"
+        image: esimonetti/sugardockerized:mysql5.7-1.03
+        ports:
+            - "3306:3306"
+        volumes:
+            - ../../data/mysql/57:/var/lib/mysql
+        environment:
+            - MYSQL_ROOT_PASSWORD=root
+            - MYSQL_USER=sugar
+            - MYSQL_PASSWORD=sugar
+    elasticsearch:
+        container_name: "sugar-elasticsearch"
+        image: esimonetti/sugardockerized:elasticsearch6.2
+        volumes:
+            - ../../data/elasticsearch/62:/usr/share/elasticsearch/data
+        environment:
+            - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+        ulimits:
+            memlock:
+                soft: -1
+                hard: -1
+        mem_limit: 1g
+    redis:
+        container_name: "sugar-redis"
+        image: redis:latest
+        volumes:
+            - ../../data/redis:/data
+    permissions:
+        container_name: "sugar-permissions"
+        image: esimonetti/sugardockerized:permissions
+        volumes:
+            - ../../data/app:/var/www/html


### PR DESCRIPTION
I didn't do a full test, but seemed simple enough to add elastic search 6.2 support, which is now supported in 8.1, and is also backported into 8.0.1 (soon to be released).