### PR TITLE
Added elastic 6.2 xpack.monitoring.enabled: false 

### DIFF
--- a/images/elasticsearch/62/config/elasticsearch/elasticsearch.yml
+++ b/images/elasticsearch/62/config/elasticsearch/elasticsearch.yml
@@ -5,5 +5,6 @@ cluster.indices.close.enable: false
 script.allowed_types: none
 script.allowed_contexts: search
 xpack.security.enabled: false
+xpack.monitoring.enabled: false
 bootstrap.memory_lock: true
 network.host: _site_

--- a/stacks/sugar81/php71.yml
+++ b/stacks/sugar81/php71.yml
@@ -46,7 +46,7 @@ services:
             - MYSQL_PASSWORD=sugar
     elasticsearch:
         container_name: "sugar-elasticsearch"
-        image: esimonetti/sugardockerized:elasticsearch6.2
+        image: esimonetti/sugardockerized:elasticsearch6.2-1.05
         volumes:
             - ../../data/elasticsearch/62:/usr/share/elasticsearch/data
         environment:


### PR DESCRIPTION
The setting is to prevent license errors for xpack, as it is not in use