### PR TITLE
Macos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 data
+.DS_Store
+.idea/
+

--- a/README.md
+++ b/README.md
@@ -314,3 +314,10 @@ Tweak the above settings based on your specific needs.
 ## Mac users notes
 These stacks have been built on a Mac platform, that is known to not perform well with [Docker mounted volumes](https://github.com/docker/for-mac/issues/77).
 Personally I run Docker on a Debian based minimal VirtualBox VM with fixed IP, running a NFS server. I either mount NFS on my Mac when needed or SSH directly into the VM. [The Debian Docker VirtualBox VM for Mac is available here](https://github.com/esimonetti/DebianDockerMac) with its [latest downloadable version here](https://github.com/esimonetti/DebianDockerMac/releases/latest).
+
+## Karel's comment
+This branch is a fork for macos - docker is using volumes instead of regular filesystem. At this stage, only stacks/sugar8/php71-local-build.yml compose file works.
+
+You can run it like `docker-compose -f <path>/stacks/sugar8/php71-local-build.yml up -d`. After that you need to run script `utilities/setsshkey.sh` which will setup ssh key. After that, you can ssh to server as usual. The sugar root is `/var/www/html/sugar` not `sugarcrm`!!
+
+Have fun :)

--- a/images/php/71/apache/Dockerfile
+++ b/images/php/71/apache/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y graphviz --no-install-recommends && rm 
 COPY config/apache2/mods-available/deflate.conf /etc/apache2/mods-available/deflate.conf
 RUN a2enmod headers expires deflate rewrite
 
-RUN adduser sugar --disabled-password --disabled-login --gecos ""
+RUN adduser sugar --uid 1500 --disabled-password --disabled-login --gecos ""
 RUN sed -i "s#APACHE_RUN_USER=.*#APACHE_RUN_USER=sugar#" /etc/apache2/envvars \
     && sed -i "s#APACHE_RUN_GROUP=.*#APACHE_RUN_GROUP=sugar#" /etc/apache2/envvars
 

--- a/images/php/71/ssh/Dockerfile
+++ b/images/php/71/ssh/Dockerfile
@@ -1,6 +1,7 @@
 FROM esimonetti/sugarphp71image:1.4
 MAINTAINER enrico.simonetti@gmail.com
 
+RUN adduser sugar --uid 1500 --disabled-password --disabled-login --gecos ""
 RUN apt-get update && apt-get install -y openssh-server zip unzip git
 RUN apt-get clean && apt-get -y autoremove
 RUN mkdir /var/run/sshd

--- a/images/php/71/ssh/Dockerfile
+++ b/images/php/71/ssh/Dockerfile
@@ -1,3 +1,6 @@
+FROM esimonetti/sugarphp71image:1.4
+MAINTAINER enrico.simonetti@gmail.com
+
 RUN apt-get update && apt-get install -y openssh-server zip unzip git
 RUN apt-get clean && apt-get -y autoremove
 RUN mkdir /var/run/sshd

--- a/images/php/71/ssh/Dockerfile
+++ b/images/php/71/ssh/Dockerfile
@@ -1,6 +1,4 @@
-RUN adduser sugar --disabled-password --disabled-login --gecos ""
 RUN apt-get update && apt-get install -y openssh-server zip unzip git
 RUN apt-get clean && apt-get -y autoremove
 RUN mkdir /var/run/sshd
 CMD ["/usr/sbin/sshd", "-D"]
-

--- a/images/php/71/ssh/Dockerfile
+++ b/images/php/71/ssh/Dockerfile
@@ -1,0 +1,6 @@
+RUN adduser sugar --disabled-password --disabled-login --gecos ""
+RUN apt-get update && apt-get install -y openssh-server zip unzip git
+RUN apt-get clean && apt-get -y autoremove
+RUN mkdir /var/run/sshd
+CMD ["/usr/sbin/sshd", "-D"]
+

--- a/stacks/sugar8/php71-local-build.yml
+++ b/stacks/sugar8/php71-local-build.yml
@@ -1,12 +1,6 @@
 version: '2'
 
 services:
-    web1_volumes:
-        image: busybox
-        container_name: "sugar-web1-volumes"
-        volumes:
-        - web_volume:/var/www/html:z
-        - log_volume:/var/log:z
 
     web1:
         container_name: "sugar-web1"
@@ -17,8 +11,9 @@ services:
         - "80:80"
         extra_hosts:
         - "docker.local:127.0.0.1"
-        volumes_from:
-        - web1_volumes
+        volumes:
+        - web_volume:/var/www/html:z
+        - log_volume:/var/log:z
         depends_on:
         - mysql
         - elasticsearch
@@ -34,16 +29,18 @@ services:
         build: ../../images/php/71/ssh
         ports:
         - "14022:22"
-        volumes_from:
-            - web1_volumes
         volumes:
+        - web_volume:/var/www/html:z
+        - log_volume:/var/log:z
         - ssh_volume:/home/sugar:z
+
     cron:
         container_name: "sugar-cron"
         image: sugar_php71_cron
         build: ../../images/php/71/cron
-        volumes_from:
-        - web1_volumes
+        volumes:
+        - web_volume:/var/www/html:z
+        - log_volume:/var/log:z
         depends_on:
             - mysql
             - elasticsearch
@@ -53,6 +50,7 @@ services:
             - mysql
             - elasticsearch
             - redis
+
     mysql:
         container_name: "sugar-mysql"
         image: sugar_mysql
@@ -87,8 +85,9 @@ services:
         container_name: "sugar-permissions"
         image: sugar_permissions
         build: ../../images/permissions
-        volumes_from:
-        - web1_volumes
+        volumes:
+        - web_volume:/var/www/html:z
+        - log_volume:/var/log:z
 
 
 volumes:

--- a/stacks/sugar8/php71-local-build.yml
+++ b/stacks/sugar8/php71-local-build.yml
@@ -1,31 +1,49 @@
 version: '2'
 
 services:
+    web1_volumes:
+        image: busybox
+        container_name: "sugar-web1-volumes"
+        volumes:
+        - web_volume:/var/www/html:z
+        - log_volume:/var/log:z
+
     web1:
         container_name: "sugar-web1"
         image: sugar_php71_web
         build: ../../images/php/71/apache
+
         ports:
-            - "80:80"
+        - "80:80"
         extra_hosts:
-            - "docker.local:127.0.0.1"
-        volumes:
-            - ../../data/app:/var/www/html
+        - "docker.local:127.0.0.1"
+        volumes_from:
+        - web1_volumes
         depends_on:
-            - mysql
-            - elasticsearch
-            - redis
-            - permissions
+        - mysql
+        - elasticsearch
+        - redis
+        - permissions
         links:
-            - mysql
-            - elasticsearch
-            - redis
+        - mysql
+        - elasticsearch
+        - redis
+    ssh:
+        container_name: "sugar-ssh"
+        image: sugar_php71_ssh
+        build: ../../images/php/71/ssh
+        ports:
+        - "14022:22"
+        volumes_from:
+            - web1_volumes
+        volumes:
+        - ssh_volume:/home/sugar:z
     cron:
         container_name: "sugar-cron"
         image: sugar_php71_cron
         build: ../../images/php/71/cron
-        volumes:
-            - ../../data/app:/var/www/html
+        volumes_from:
+        - web1_volumes
         depends_on:
             - mysql
             - elasticsearch
@@ -42,7 +60,7 @@ services:
         ports:
             - "3306:3306"
         volumes:
-            - ../../data/mysql/57:/var/lib/mysql
+        - mysql_volume:/var/lib/mysql:z
         environment:
             - MYSQL_ROOT_PASSWORD=root
             - MYSQL_USER=sugar
@@ -52,7 +70,7 @@ services:
         image: sugar_elastic56
         build: ../../images/elasticsearch/56
         volumes:
-            - ../../data/elasticsearch/56:/usr/share/elasticsearch/data
+        - elasticsearch_volume:/usr/share/elasticsearch/data:z
         environment:
             - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
         ulimits:
@@ -64,10 +82,25 @@ services:
         container_name: "sugar-redis"
         image: redis:latest
         volumes:
-            - ../../data/redis:/data
+        - redis_volume:/data:z
     permissions:
         container_name: "sugar-permissions"
         image: sugar_permissions
         build: ../../images/permissions
-        volumes:
-            - ../../data/app:/var/www/html
+        volumes_from:
+        - web1_volumes
+
+
+volumes:
+    mysql_volume:
+        driver: local
+    web_volume:
+        driver: local
+    log_volume:
+        driver: local
+    elasticsearch_volume:
+        driver: local
+    redis_volume:
+        driver: local
+    ssh_volume:
+        driver: local

--- a/stacks/sugar8/php71.yml
+++ b/stacks/sugar8/php71.yml
@@ -1,71 +1,56 @@
 version: '2'
 
 services:
-    mysql_volume:
-        image: busybox
-        container_name: mysql_volume
-        volumes:
-        - mysql_volume:/var/lib/mysql:z
-
-    web1_volume:
-        image: busybox
-        container_name: sugarcrm_data
-        volumes:
-        - web1_volume:/var/www/html:z
-
     web1:
         container_name: "sugar-web1"
         image: esimonetti/sugardockerized:php7.1-apache-1.01
         ports:
-        - "80:80"
-        - "14022:22"
+            - "80:80"
         extra_hosts:
-        - "docker.local:127.0.0.1"
-        volumes_from:
-        - web1_volume
+            - "docker.local:127.0.0.1"
         volumes:
-            - log_volume:/var/log:Z
+            - ../../data/app:/var/www/html
         depends_on:
-        - mysql
-        - elasticsearch
-        - redis
-        - permissions
+            - mysql
+            - elasticsearch
+            - redis
+            - permissions
         links:
-        - mysql
-        - elasticsearch
-        - redis
+            - mysql
+            - elasticsearch
+            - redis
     cron:
         container_name: "sugar-cron"
         image: esimonetti/sugardockerized:php7.1-cron-1.01
-        volumes_from:
-        - web1_volume
+        volumes:
+            - ../../data/app:/var/www/html
         depends_on:
-        - mysql
-        - elasticsearch
-        - redis
-        - permissions
+            - mysql
+            - elasticsearch
+            - redis
+            - permissions
         links:
-        - mysql
-        - elasticsearch
-        - redis
+            - mysql
+            - elasticsearch
+            - redis
     mysql:
         container_name: "sugar-mysql"
         image: esimonetti/sugardockerized:mysql5.7-1.06
         ports:
-        - "3306:3306"
-        volumes_from:
-        - mysql_volume
+            - "3306:3306"
+        volumes:
+            - ../../data/mysql/57:/var/lib/mysql
         environment:
-        - MYSQL_ROOT_PASSWORD=root
-        - MYSQL_USER=sugar
-        - MYSQL_PASSWORD=sugar
+            - MYSQL_ROOT_PASSWORD=root
+            - MYSQL_USER=sugar
+            - MYSQL_PASSWORD=sugar
     elasticsearch:
         container_name: "sugar-elasticsearch"
         image: esimonetti/sugardockerized:elasticsearch5.6
         volumes:
-        - elasticsearch_volume:/usr/share/elasticsearch/data:z
+            - ../../data/elasticsearch/56:/usr/share/elasticsearch/data
         environment:
-        - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+            - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
         ulimits:
             memlock:
                 soft: -1
@@ -75,21 +60,9 @@ services:
         container_name: "sugar-redis"
         image: redis:latest
         volumes:
-        - redis_volume:/data:z
+            - ../../data/redis:/data
     permissions:
         container_name: "sugar-permissions"
         image: esimonetti/sugardockerized:permissions
-        volumes_from:
-        - web1_volume
-
-volumes:
-    mysql_volume:
-        driver: local
-    web1_volume:
-        driver: local
-    log_volume:
-        driver: local
-    elasticsearch_volume:
-        driver: local
-    redis_volume:
-        driver: local
+        volumes:
+            - ../../data/app:/var/www/html

--- a/stacks/sugar8/php71.yml
+++ b/stacks/sugar8/php71.yml
@@ -1,56 +1,71 @@
 version: '2'
 
 services:
+    mysql_volume:
+        image: busybox
+        container_name: mysql_volume
+        volumes:
+        - mysql_volume:/var/lib/mysql:z
+
+    web1_volume:
+        image: busybox
+        container_name: sugarcrm_data
+        volumes:
+        - web1_volume:/var/www/html:z
+
     web1:
         container_name: "sugar-web1"
         image: esimonetti/sugardockerized:php7.1-apache-1.01
         ports:
-            - "80:80"
+        - "80:80"
+        - "14022:22"
         extra_hosts:
-            - "docker.local:127.0.0.1"
+        - "docker.local:127.0.0.1"
+        volumes_from:
+        - web1_volume
         volumes:
-            - ../../data/app:/var/www/html
+            - log_volume:/var/log:Z
         depends_on:
-            - mysql
-            - elasticsearch
-            - redis
-            - permissions
+        - mysql
+        - elasticsearch
+        - redis
+        - permissions
         links:
-            - mysql
-            - elasticsearch
-            - redis
+        - mysql
+        - elasticsearch
+        - redis
     cron:
         container_name: "sugar-cron"
         image: esimonetti/sugardockerized:php7.1-cron-1.01
-        volumes:
-            - ../../data/app:/var/www/html
+        volumes_from:
+        - web1_volume
         depends_on:
-            - mysql
-            - elasticsearch
-            - redis
-            - permissions
+        - mysql
+        - elasticsearch
+        - redis
+        - permissions
         links:
-            - mysql
-            - elasticsearch
-            - redis
+        - mysql
+        - elasticsearch
+        - redis
     mysql:
         container_name: "sugar-mysql"
         image: esimonetti/sugardockerized:mysql5.7-1.06
         ports:
-            - "3306:3306"
-        volumes:
-            - ../../data/mysql/57:/var/lib/mysql
+        - "3306:3306"
+        volumes_from:
+        - mysql_volume
         environment:
-            - MYSQL_ROOT_PASSWORD=root
-            - MYSQL_USER=sugar
-            - MYSQL_PASSWORD=sugar
+        - MYSQL_ROOT_PASSWORD=root
+        - MYSQL_USER=sugar
+        - MYSQL_PASSWORD=sugar
     elasticsearch:
         container_name: "sugar-elasticsearch"
         image: esimonetti/sugardockerized:elasticsearch5.6
         volumes:
-            - ../../data/elasticsearch/56:/usr/share/elasticsearch/data
+        - elasticsearch_volume:/usr/share/elasticsearch/data:z
         environment:
-            - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+        - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
         ulimits:
             memlock:
                 soft: -1
@@ -60,9 +75,21 @@ services:
         container_name: "sugar-redis"
         image: redis:latest
         volumes:
-            - ../../data/redis:/data
+        - redis_volume:/data:z
     permissions:
         container_name: "sugar-permissions"
         image: esimonetti/sugardockerized:permissions
-        volumes:
-            - ../../data/app:/var/www/html
+        volumes_from:
+        - web1_volume
+
+volumes:
+    mysql_volume:
+        driver: local
+    web1_volume:
+        driver: local
+    log_volume:
+        driver: local
+    elasticsearch_volume:
+        driver: local
+    redis_volume:
+        driver: local

--- a/utilities/repairknownhosts.sh
+++ b/utilities/repairknownhosts.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sed -ie "s/^.*localhost.*//" ~/.ssh/known_hosts

--- a/utilities/setsshkey.sh
+++ b/utilities/setsshkey.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+tmpkey=`cat ~/.ssh/id_rsa.pub`
+docker exec -i sugar-ssh bash -c "mkdir /home/sugar/.ssh"
+docker exec -i sugar-ssh bash -c "echo \"$tmpkey\" > /home/sugar/.ssh/authorized_keys"
+tmpkey=''

--- a/utilities/setsshkey.sh
+++ b/utilities/setsshkey.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 tmpkey=`cat ~/.ssh/id_rsa.pub`
-docker exec -i sugar-ssh bash -c "mkdir /home/sugar/.ssh"
-docker exec -i sugar-ssh bash -c "echo \"$tmpkey\" > /home/sugar/.ssh/authorized_keys"
+docker exec -i --user sugar sugar-ssh bash -c "mkdir /home/sugar/.ssh"
+docker exec -i --user sugar sugar-ssh bash -c "echo \"$tmpkey\" > /home/sugar/.ssh/authorized_keys"
 tmpkey=''


### PR DESCRIPTION
Hi, first I would like to thank you for the SugarStack for 8.0, it's awesome!

We work entirely on macbooks and don't want to install virtual machines. As you have mentioned, when using a filesystem directly, it's pretty slow on macOS. But when we use docker volumes, the performance is much much better, i'd say better than combination of virtual machine with docker using filesystem. 

The only downside is that accessing sugar files is really inconvenient. That's why I also added ssh container - normal development with PhpStorm is almost like working with local files, when you set up everything correctly.

To make things easier, I added two scripts to utils - one copies your public ssh key to the container, so you can login as sugar user (we need to log in as this user to not to mess with files ownership). 

Second removes localhost record from known hosts, because when you restart the container, it's identity changes and mac console won't let you in because there would be a conflict.

I altered only the 8.0 local build compose file before making any further changes because I don't even know if you are interested in these changes, want to make a new branch from it and also to create new containers on dockerhub.

Please let me know whether we should create our own dockerhub, or we will somehow collaborate :)

This is also my first docker project i've worked on, so please be critical.