### PR TITLE
Update sugarfixpermissions to be faster on slow filesystems (EFS, OSXFS, etc)

### DIFF
--- a/images/permissions/apps/sugarfixpermissions
+++ b/images/permissions/apps/sugarfixpermissions
@@ -1,14 +1,21 @@
-#!/bin/bash
-cd /var/www/html
-chown -R 1000:1000 .
-cd sugar
-if [ -e ./bin/sugarcrm ]
+#!/usr/bin/env bash
+
+DIR=/var/www/html
+
+# Only change ownership on files that aren't currently owned by sugar:sugar
+find ${DIR} -noleaf \( \! -user sugar -o \! -group sugar \) -print0 | xargs -0 -r chown sugar:sugar
+
+# Only change the mode of files/directories that are not 664/775
+find ${DIR} -noleaf -type d \! -perm 775 -print0 2> /dev/null | xargs -0 -r chmod 775 2> /dev/null
+find ${DIR} -noleaf -type f \! -perm 664 -print0 2> /dev/null | xargs -0 -r chmod 664 2> /dev/null
+
+# Directly set these to mode 700
+if [ -e ${DIR}/sugar/bin/sugarcrm ]
 then
-    chmod 700 ./bin/sugarcrm
+    chmod 700 ${DIR}/sugarbin/sugarcrm
 fi
-if [ -e ./vendor/phpunit/phpunit/phpunit ]
+
+if [ -e ${DIR}/sugar/vendor/phpunit/phpunit/phpunit ]
 then
-    chmod 700 ./vendor/phpunit/phpunit/phpunit
+    chmod 700 ${DIR}/sugar/vendor/phpunit/phpunit/phpunit
 fi
-find . -type d -exec chmod 775 {} \;
-find . -type f ! -name phpunit ! -name sugarcrm -exec chmod 664 {} \;

--- a/images/permissions/apps/sugarfixpermissions
+++ b/images/permissions/apps/sugarfixpermissions
@@ -15,7 +15,7 @@ then
     chmod 700 ${DIR}/sugar/bin/sugarcrm
 fi
 
-if [ -e ${DIR}/sugar/vendor/phpunit/phpunit/phpunit ]
+if [ -e ${DIR}/sugar/vendor/phpunit/bin/phpunit ]
 then
-    chmod 700 ${DIR}/sugar/vendor/phpunit/phpunit/phpunit
+    chmod 700 ${DIR}/sugar/vendor/phpunit/bin/phpunit
 fi

--- a/images/permissions/apps/sugarfixpermissions
+++ b/images/permissions/apps/sugarfixpermissions
@@ -12,7 +12,7 @@ find ${DIR} -noleaf -type f \! -perm 664 -print0 2> /dev/null | xargs -0 -r chmo
 # Directly set these to mode 700
 if [ -e ${DIR}/sugar/bin/sugarcrm ]
 then
-    chmod 700 ${DIR}/sugarbin/sugarcrm
+    chmod 700 ${DIR}/sugar/bin/sugarcrm
 fi
 
 if [ -e ${DIR}/sugar/vendor/phpunit/phpunit/phpunit ]

--- a/images/permissions/apps/sugarfixpermissions
+++ b/images/permissions/apps/sugarfixpermissions
@@ -15,7 +15,7 @@ then
     chmod 700 ${DIR}/sugar/bin/sugarcrm
 fi
 
-if [ -e ${DIR}/sugar/vendor/phpunit/bin/phpunit ]
+if [ -e ${DIR}/sugar/vendor/phpunit/phpunit/phpunit ]
 then
-    chmod 700 ${DIR}/sugar/vendor/phpunit/bin/phpunit
+    chmod 700 ${DIR}/sugar/vendor/phpunit/phpunit/phpunit
 fi

--- a/images/php/71/cron/config/php/mods-available/opcache.ini
+++ b/images/php/71/cron/config/php/mods-available/opcache.ini
@@ -1,7 +1,7 @@
 ; configuration for php ZendOpcache module
 ; priority=10
 zend_extension=opcache.so
-opcache.blacklist_filename="/etc/php/7.1/opcache-blacklist"
+opcache.blacklist_filename="/usr/local/etc/php/opcache-blacklist"
 opcache.consistency_checks=0
 opcache.dups_fix=0
 opcache.enable=1

--- a/images/php/73/cron/config/php/mods-available/opcache.ini
+++ b/images/php/73/cron/config/php/mods-available/opcache.ini
@@ -1,7 +1,7 @@
 ; configuration for php ZendOpcache module
 ; priority=10
 zend_extension=opcache.so
-opcache.blacklist_filename="/etc/php/7.1/opcache-blacklist"
+opcache.blacklist_filename="/usr/local/etc/php/opcache-blacklist"
 opcache.consistency_checks=0
 opcache.dups_fix=0
 opcache.enable=1


### PR DESCRIPTION
You might want to double check the paths, you had vendor/phpunit/phpunit/phpunit but if I recall it's actually vendor/phpunit/bin/phpunit.

I also updated 2 of the opcache configurations to use the file location given in the Dockerfile.