### PR TITLE
Added xdebug.sh. Updated version of Xdebug for PHP 7.3. Updated READM…

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Apache web servers have enabled:
 Apache web servers have PHP with enabled:
 * Zend OPcache - Configured for Sugar with the assumption the files will be located within the correct path
 * XHProf and Tideways profilers
-* Xdebug is installed but it is not enabled by default (due to its performance impact). If there is the need to enable it, you would have to uncomment the configuration option on the PHP Dockerfile of choice, and leverage the stack configuration with local build.
+* Xdebug is installed but it is not enabled by default (due to its performance impact). For PHP 5.6 images and all cron images if there is the need to enable it, you would have to uncomment the configuration option on the PHP Dockerfile of choice, and leverage the stack configuration with local build. For other case see [`xdebug.sh`](#xdebugsh).
     * If you use an IDE such as PHPStorm, you can setup DBGp Proxy under the menus Preference -> Language & Framework -> PHP -> Debug -> DBGp Proxy. Example settings are available in the screenshot below:
 
       <img width="1026" alt="PHPStorm xdebug settings" src="https://user-images.githubusercontent.com/361254/38972661-d48661f6-4356-11e8-9245-ad598239fe94.png">
@@ -177,6 +177,49 @@ If you do need multiple instances, as long as they are not running at the same t
 
 ### Utilities
 To help with development, there are a set of tools provided within the `utilities` [directory of this repository](utilities). Some of the scripts are mentioned below.
+
+#### xdebug.sh
+```./utilities/xdebug.sh [status | start | stop]```
+```
+./utilities/xdebug.sh status
+xDebug status
+PHP 7.1.33 (cli) (built: Nov 22 2019 18:28:25) ( NTS )
+Copyright (c) 1997-2018 The PHP Group
+Zend Engine v3.1.0, Copyright (c) 1998-2018 Zend Technologies
+    with Zend OPcache v7.1.33, Copyright (c)1999-2018, by Zend Technologies
+```
+```
+./utilities/xdebug.sh start
+Start xDebug
+6c9a9862b60c
+PHP 7.1.33 (cli) (built: Nov 22 2019 18:28:25) ( NTS )
+Copyright (c) 1997-2018 The PHP Group
+Zend Engine v3.1.0, Copyright (c) 1998-2018 Zend Technologies
+    with Zend OPcache v7.1.33, Copyright (c) 1999-2018, by Zend Technologies
+    with Xdebug v2.9.2, Copyright (c) 2002-2020, by Derick Rethans
+```
+```
+./utilities/xdebug.sh stop
+Stop xDebug
+6c9a9862b60c
+PHP 7.1.33 (cli) (built: Nov 22 2019 18:28:25) ( NTS )
+Copyright (c) 1997-2018 The PHP Group
+Zend Engine v3.1.0, Copyright (c) 1998-2018 Zend Technologies
+    with Zend OPcache v7.1.33, Copyright (c) 1999-2018, by Zend Technologies
+```
+Due to performance impact, Xdebug is disabled by default. This script prompts you to activate Xdebug, check if Xdebug is activated, or disable it.
+If you do not want to configure DBGp Proxy when running the script, you can specify the second argument `change-ip`. In this case, the script will change the `xdebug.remote_host` option to your local IP address.
+```
+./utilities/xdebug.sh start change-ip
+Start xDebug
+New IP of remote_host: 192.168.0.105
+6c9a9862b60c
+PHP 7.1.33 (cli) (built: Nov 22 2019 18:28:25) ( NTS )
+Copyright (c) 1997-2018 The PHP Group
+Zend Engine v3.1.0, Copyright (c) 1998-2018 Zend Technologies
+    with Zend OPcache v7.1.33, Copyright (c) 1999-2018, by Zend Technologies
+    with Xdebug v2.9.2, Copyright (c) 2002-2020, by Derick Rethans
+```
 
 #### setownership.sh
 ```./utilities/setownership.sh```

--- a/images/php/71/apache/Dockerfile
+++ b/images/php/71/apache/Dockerfile
@@ -72,8 +72,7 @@ RUN docker-php-ext-install mysqli \
     && pecl install redis \
     && docker-php-ext-enable redis
 
-# disable by default, it can be enabled locally
-#COPY config/php/mods-available/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
+COPY config/php/mods-available/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
 COPY config/php/mods-available/opcache.ini /usr/local/etc/php/conf.d/opcache.ini
 COPY config/php/opcache-blacklist /usr/local/etc/php/opcache-blacklist
 

--- a/images/php/71/apache/config/php/mods-available/xdebug.ini
+++ b/images/php/71/apache/config/php/mods-available/xdebug.ini
@@ -1,4 +1,4 @@
-zend_extension=xdebug.so
+;zend_extension=xdebug.so
 xdebug.max_nesting_level=500
 xdebug.profiler_enable=0
 

--- a/images/php/73/apache/Dockerfile
+++ b/images/php/73/apache/Dockerfile
@@ -66,13 +66,11 @@ RUN docker-php-ext-install mysqli \
     && docker-php-ext-install zip \
     && docker-php-ext-install ldap \
     && docker-php-ext-install pcntl \
-    # problem for xdebug 2.6.1 with php 7.3rc (https://bugs.xdebug.org/view.php?id=1584)
-    && pecl install xdebug-2.7.0beta1 \
+    && pecl install xdebug-2.9.5 \
     && pecl install redis \
     && docker-php-ext-enable redis
 
-# disable by default, it can be enabled locally
-#COPY config/php/mods-available/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
+COPY config/php/mods-available/xdebug.ini /usr/local/etc/php/conf.d/xdebug.ini
 COPY config/php/mods-available/opcache.ini /usr/local/etc/php/conf.d/opcache.ini
 COPY config/php/opcache-blacklist /usr/local/etc/php/opcache-blacklist
 

--- a/images/php/73/apache/config/php/mods-available/xdebug.ini
+++ b/images/php/73/apache/config/php/mods-available/xdebug.ini
@@ -1,4 +1,4 @@
-zend_extension=xdebug.so
+;zend_extension=xdebug.so
 xdebug.max_nesting_level=500
 xdebug.profiler_enable=0
 

--- a/utilities/xdebug.sh
+++ b/utilities/xdebug.sh
@@ -1,0 +1,76 @@
+#! /bin/bash
+
+# Grab full name of php container
+PHP_CONTAINER=$(docker ps | grep sugar-web1 | awk '{print $1}')
+
+getMyIP ()
+{
+    local _ip _myip _line _nl=$'\n'
+    while IFS=$': \t' read -a _line ;do
+        [ -z "${_line%inet}" ] &&
+           _ip=${_line[${#_line[1]}>4?1:2]} &&
+           [ "${_ip#127.0.0.1}" ] && _myip=$_ip
+      done< <(LANG=C /sbin/ifconfig)
+    printf ${1+-v} $1 "%s${_nl:0:$[${#1}>0?0:1]}" $_myip
+}
+
+xdebug_status ()
+{
+    echo 'xDebug status'
+    docker exec -it $PHP_CONTAINER bash -c 'php -v'
+}
+
+xdebug_start ()
+{
+    echo 'Start xDebug'
+
+    # Uncomment line with xdebug extension, thus enabling it
+    ON_CMD="sed -i 's/^;zend_extension=/zend_extension=/g' \
+                    /usr/local/etc/php/conf.d/xdebug.ini"
+    docker exec -it $PHP_CONTAINER bash -c "${ON_CMD}"
+
+    if [[ "$1" == "change-ip" ]]; then
+        # Grab IP address of eth0
+        IP=$(getMyIP)
+        # Change IP address for parameter xdebug.remote_host
+        IP_CMD="sed -i 's/^xdebug.remote_host=.*/xdebug.remote_host=$IP/g' \
+                     /usr/local/etc/php/conf.d/xdebug.ini"
+        docker exec -it $PHP_CONTAINER bash -c "${IP_CMD}"
+        echo "New IP of remote_host: $IP"
+    fi
+
+    docker restart $PHP_CONTAINER
+    docker exec -it $PHP_CONTAINER bash -c 'php -v'
+}
+
+xdebug_stop ()
+{
+    echo 'Stop xDebug'
+
+    # Comment out xdebug extension line
+    OFF_CMD="sed -i 's/^zend_extension=/;zend_extension=/g' /usr/local/etc/php/conf.d/xdebug.ini"
+
+    docker exec -it $PHP_CONTAINER bash -c "${OFF_CMD}"
+    docker restart $PHP_CONTAINER
+    docker exec -it $PHP_CONTAINER bash -c 'php -v'
+}
+
+case $1 in
+    stop|STOP)
+        xdebug_stop
+        ;;
+    start|START)
+        xdebug_start "$2"
+        ;;
+    status|STATUS)
+        xdebug_status
+        ;;
+    *)
+        echo "xDebug [Stop | Start | Status] in the ${PHP_FPM_CONTAINER} container."
+        echo "xDebug must have already been installed."
+        echo "Usage:"
+        echo "  .php/xdebug stop|start|status"
+
+esac
+
+exit 1


### PR DESCRIPTION
Hello Enrico,

To simplify working with Xdebug, I suggest adding a new script xdebug.sh, which allows you to activate, check status or deactivate Xdebug. This will allow us not to rebuild containers when we need to activate or deactivate Xdebug.

I also updated the version of Xdebug for PHP 7.3 and README.md.
